### PR TITLE
Move infrahouse.com zone to a module

### DIFF
--- a/modules/infrahouse.com/main.tf
+++ b/modules/infrahouse.com/main.tf
@@ -1,0 +1,48 @@
+resource "aws_route53_zone" "infrahouse_com" {
+  name = "infrahouse.com"
+}
+
+## MX
+resource "aws_route53_record" "mx" {
+  name    = aws_route53_zone.infrahouse_com.name
+  type    = "MX"
+  zone_id = aws_route53_zone.infrahouse_com.id
+  ttl     = 3600
+  records = [
+    "1 aspmx.l.google.com.",
+    "5 alt1.aspmx.l.google.com.",
+    "5 alt2.aspmx.l.google.com.",
+    "10 alt3.aspmx.l.google.com.",
+    "10 alt4.aspmx.l.google.com."
+  ]
+}
+
+resource "aws_route53_record" "spf" {
+  name    = aws_route53_zone.infrahouse_com.name
+  type    = "SPF"
+  zone_id = aws_route53_zone.infrahouse_com.id
+  records = [
+    "\"v=spf1 include:_spf.google.com ~all\""
+  ]
+  ttl = 3600
+}
+
+resource "aws_route53_record" "txt_spf" {
+  name    = aws_route53_zone.infrahouse_com.name
+  type    = "TXT"
+  zone_id = aws_route53_zone.infrahouse_com.id
+  records = [
+    "\"v=spf1 include:_spf.google.com ~all\""
+  ]
+  ttl = 3600
+}
+
+resource "aws_route53_record" "txt_dkim" {
+  name    = "google._domainkey.${aws_route53_zone.infrahouse_com.name}"
+  type    = "TXT"
+  zone_id = aws_route53_zone.infrahouse_com.id
+  records = [
+    "\"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhRsHTvHGTZIg60W5xybWjEAa3dbxh1qUxM5yS4LAEOtPm6dlNO88SMbXQP+h82kffiOukmWnEgzoUmDs8yEqn9AuMpEsVLH5tLbzpQhWOAzEJ5aLQKtgb5snES2gdkb2jeZX60dhBm9CzlZHhBiSZRp1+hWu02f9aLe2WYwFsL/lsQsTwzYN8mTc83l/UQ2e/\" \"adsylAdWJlPmd9p8VIr63aMLVBmid2AWDQnj1RgKOHNARz6d3meTg602EEiI0+0OzHd8Zdc16kY3NUYZ1u8GBuCA5hleAYtefshhmwn5pSg375urhl3+480vp0H/jyq+DGYrDZ5Cqwgd2HjSCrzFwIDAQAB\""
+  ]
+  ttl = 3600
+}

--- a/modules/infrahouse.com/outputs.tf
+++ b/modules/infrahouse.com/outputs.tf
@@ -1,0 +1,3 @@
+output "infrahouse_ns" {
+  value = aws_route53_zone.infrahouse_com.name_servers
+}

--- a/modules/infrahouse.com/terraform.tf
+++ b/modules/infrahouse.com/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.67"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "infrahouse_ns" {
-  value = aws_route53_zone.infrahouse_com.name_servers
+  value = module.infrahouse_com.infrahouse_ns
 }

--- a/route53.infrahouse.com.tf
+++ b/route53.infrahouse.com.tf
@@ -1,49 +1,6 @@
-resource "aws_route53_zone" "infrahouse_com" {
-  provider = aws.aws-493370826424-uw1
-  name     = "infrahouse.com"
-}
-
-## MX
-resource "aws_route53_record" "mx" {
-  name    = aws_route53_zone.infrahouse_com.name
-  type    = "MX"
-  zone_id = aws_route53_zone.infrahouse_com.id
-  ttl     = 3600
-  records = [
-    "1 aspmx.l.google.com.",
-    "5 alt1.aspmx.l.google.com.",
-    "5 alt2.aspmx.l.google.com.",
-    "10 alt3.aspmx.l.google.com.",
-    "10 alt4.aspmx.l.google.com."
-  ]
-}
-
-resource "aws_route53_record" "spf" {
-  name    = aws_route53_zone.infrahouse_com.name
-  type    = "SPF"
-  zone_id = aws_route53_zone.infrahouse_com.id
-  records = [
-    "\"v=spf1 include:_spf.google.com ~all\""
-  ]
-  ttl = 3600
-}
-
-resource "aws_route53_record" "txt_spf" {
-  name    = aws_route53_zone.infrahouse_com.name
-  type    = "TXT"
-  zone_id = aws_route53_zone.infrahouse_com.id
-  records = [
-    "\"v=spf1 include:_spf.google.com ~all\""
-  ]
-  ttl = 3600
-}
-
-resource "aws_route53_record" "txt_dkim" {
-  name    = "google._domainkey.${aws_route53_zone.infrahouse_com.name}"
-  type    = "TXT"
-  zone_id = aws_route53_zone.infrahouse_com.id
-  records = [
-    "\"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhRsHTvHGTZIg60W5xybWjEAa3dbxh1qUxM5yS4LAEOtPm6dlNO88SMbXQP+h82kffiOukmWnEgzoUmDs8yEqn9AuMpEsVLH5tLbzpQhWOAzEJ5aLQKtgb5snES2gdkb2jeZX60dhBm9CzlZHhBiSZRp1+hWu02f9aLe2WYwFsL/lsQsTwzYN8mTc83l/UQ2e/\" \"adsylAdWJlPmd9p8VIr63aMLVBmid2AWDQnj1RgKOHNARz6d3meTg602EEiI0+0OzHd8Zdc16kY3NUYZ1u8GBuCA5hleAYtefshhmwn5pSg375urhl3+480vp0H/jyq+DGYrDZ5Cqwgd2HjSCrzFwIDAQAB\""
-  ]
-  ttl = 3600
+module "infrahouse_com" {
+  source = "./modules/infrahouse.com"
+  providers = {
+    aws = aws.aws-493370826424-uw1
+  }
 }


### PR DESCRIPTION
I tend to forget a provider configuration. Putting all related stuff
into a module seems more reliable way.
