### PR TITLE
Wait until lambda archive is available

### DIFF
--- a/modules/jumphost/lambda_code.tf
+++ b/modules/jumphost/lambda_code.tf
@@ -54,4 +54,8 @@ resource "aws_s3_object" "lambda_package" {
   bucket = aws_s3_bucket.lambda_tmp.bucket
   key    = basename(data.archive_file.lambda.output_path)
   source = data.archive_file.lambda.output_path
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = "while true; do aws s3 ls ${aws_s3_bucket}/${basename(data.archive_file.lambda.output_path)} && break ; echo 'Waiting until the archive is available'; sleep 1; done"
+  }
 }

--- a/modules/jumphost/lambda_code.tf
+++ b/modules/jumphost/lambda_code.tf
@@ -56,6 +56,6 @@ resource "aws_s3_object" "lambda_package" {
   source = data.archive_file.lambda.output_path
   provisioner "local-exec" {
     interpreter = ["bash", "-c"]
-    command     = "while true; do aws s3 ls ${aws_s3_bucket}/${basename(data.archive_file.lambda.output_path)} && break ; echo 'Waiting until the archive is available'; sleep 1; done"
+    command     = "while true; do aws s3 ls ${aws_s3_bucket.lambda_tmp.bucket}/${basename(data.archive_file.lambda.output_path)} && break ; echo 'Waiting until the archive is available'; sleep 1; done"
   }
 }


### PR DESCRIPTION
An S3 object isn't available right away for clients. Often there is a
short delay. The local provisioner waits until the file is readable.
