### PR TITLE
Use ih-plan download to check s3 object

### DIFF
--- a/modules/jumphost/lambda_code.tf
+++ b/modules/jumphost/lambda_code.tf
@@ -58,9 +58,15 @@ resource "aws_s3_object" "lambda_package" {
     interpreter = ["timeout", "60", "bash", "-c"]
     command     = <<EOF
 aws sts get-caller-identity
+echo "provider's role = ${data.aws_caller_identity.current.arn}"
 while true
 do
-  aws s3 cp s3://${aws_s3_bucket.lambda_tmp.bucket}/${basename(data.archive_file.lambda.output_path)} /dev/null && break
+  ih-plan \
+    --bucket "${aws_s3_bucket.lambda_tmp.bucket}" \
+    --aws-assume-role-arn "${data.aws_caller_identity.current.arn}" \
+    download \
+    "${basename(data.archive_file.lambda.output_path)}" \
+    /dev/null && break
   echo 'Waiting until the archive is available'
   sleep 1
 done


### PR DESCRIPTION
ih-plan can assumer a role while downloading an object from S3. Use
that.
The GHA worker runs as a -github role, but the provider is configured to
assume the -admin role. The -github role can assume the -admin role.
