### PR TITLE
Ensure s3 object is available for lambda

### DIFF
--- a/modules/jumphost/lambda.tf
+++ b/modules/jumphost/lambda.tf
@@ -79,7 +79,7 @@ resource "aws_iam_role_policy_attachment" "lambda_permissions" {
 
 resource "aws_lambda_function" "update_dns" {
   s3_bucket     = aws_s3_bucket.lambda_tmp.bucket
-  s3_key        = basename(data.archive_file.lambda.output_path)
+  s3_key        = aws_s3_object.lambda_package.key
   function_name = "update_dns"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "main.lambda_handler"


### PR DESCRIPTION
It looks like lambda started updating before the s3 object was done
creating.
```
module.jumphost.aws_lambda_function.update_dns: Modifying...
[id=update_dns]
module.jumphost.aws_s3_object.lambda_package: Provisioning with
'local-exec'...
```
Utilize indirect dependency.
