### PR TITLE
Bring back lambda timeout 30 sec

### DIFF
--- a/modules/jumphost/lambda.tf
+++ b/modules/jumphost/lambda.tf
@@ -91,6 +91,7 @@ resource "aws_lambda_function" "update_dns" {
   handler       = "main.lambda_handler"
 
   runtime = "python3.9"
+  timeout = 30
   environment {
     variables = {
       "ROUTE53_ZONE_ID" : var.route53_zone_id,


### PR DESCRIPTION
A publick IP address lookup only takes 3 secods - there is no way to
squeeze all operations in the default 3 seconds timeout.
