### PR TITLE
Use Tags as method to discover PublicIPAddress

### DIFF
--- a/modules/jumphost/lambda.tf
+++ b/modules/jumphost/lambda.tf
@@ -45,9 +45,18 @@ data "aws_iam_policy_document" "lambda-permissions" {
   }
   statement {
     actions = [
-      "ec2:DescribeInstances"
+      "ec2:DescribeInstances",
+      "ec2:DescribeTags"
     ]
     resources = ["*"]
+  }
+  statement {
+    actions = [
+      "ec2:CreateTags",
+    ]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:instance/*"
+    ]
   }
   statement {
     actions = [

--- a/modules/jumphost/main.tf
+++ b/modules/jumphost/main.tf
@@ -75,7 +75,7 @@ resource "aws_autoscaling_lifecycle_hook" "launching" {
   autoscaling_group_name = aws_autoscaling_group.jumphost.name
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"
   heartbeat_timeout      = local.lifecycle_hook_wait_time
-  default_result         = "CONTINUE"
+  default_result         = "ABANDON"
 }
 
 resource "aws_autoscaling_lifecycle_hook" "terminating" {
@@ -83,5 +83,5 @@ resource "aws_autoscaling_lifecycle_hook" "terminating" {
   autoscaling_group_name = aws_autoscaling_group.jumphost.name
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"
   heartbeat_timeout      = local.lifecycle_hook_wait_time
-  default_result         = "CONTINUE"
+  default_result         = "ABANDON"
 }

--- a/modules/jumphost/update_dns/main.py
+++ b/modules/jumphost/update_dns/main.py
@@ -1,5 +1,6 @@
 from os import environ
 import boto3
+from botocore.exceptions import ClientError
 
 
 def complete_lifecycle_action(
@@ -9,6 +10,12 @@ def complete_lifecycle_action(
     instanceid,
     lifecycleactionresult="CONTINUE",
 ):
+    print("Completing lifecycle hook action")
+    print(f"{lifecyclehookname=}")
+    print(f"{autoscalinggroupname=}")
+    print(f"{lifecycleactiontoken=}")
+    print(f"{lifecycleactionresult=}")
+    print(f"{instanceid=}")
     client = boto3.client("autoscaling")
     client.complete_lifecycle_action(
         LifecycleHookName=lifecyclehookname,
@@ -54,6 +61,15 @@ def add_record(zone_id, zone_name, hostname, instance_id, ttl: int):
                 }
             ]
         },
+    )
+    ec2_client = boto3.client("ec2")
+    ec2_client.create_tags(
+        Resources=[
+            instance_id,
+        ],
+        Tags=[
+            {"Key": "PublicIpAddress", "Value": public_ip},
+        ],
     )
 
 
@@ -117,14 +133,21 @@ def remove_record(zone_id, zone_name, hostname, instance_id, ttl: int):
 def get_public_ip(instance_id):
     """Get the instance's public IP address by its instance_id"""
     ec2_client = boto3.client("ec2")
+
     response = ec2_client.describe_instances(
         InstanceIds=[
             instance_id,
         ],
     )
-    print(f"describe_instances({instance_id}):")
-    print(response)
-    return response["Reservations"][0]["Instances"][0]["PublicIpAddress"]
+    print(f"describe_instances({instance_id}): {response=}")
+    if "PublicIpAddress" in response["Reservations"][0]["Instances"][0]:
+        return response["Reservations"][0]["Instances"][0]["PublicIpAddress"]
+    else:
+        for tag in response["Reservations"][0]["Instances"][0]["Tags"]:
+            if tag["Key"] == "PublicIpAddress":
+                return tag["Value"]
+
+        raise RuntimeError(f"Could not determine public IP of {instance_id}")
 
 
 def lambda_handler(event, context):
@@ -133,6 +156,7 @@ def lambda_handler(event, context):
     lifecycle_transition = event["detail"]["LifecycleTransition"]
     print(f"{lifecycle_transition = }")
 
+    lifecycle_result = "CONTINUE"
     try:
         if lifecycle_transition == "autoscaling:EC2_INSTANCE_TERMINATING":
             remove_record(
@@ -143,17 +167,23 @@ def lambda_handler(event, context):
                 int(environ["ROUTE53_TTL"]),
             )
         elif lifecycle_transition == "autoscaling:EC2_INSTANCE_LAUNCHING":
-            add_record(
-                environ["ROUTE53_ZONE_ID"],
-                environ["ROUTE53_ZONE_NAME"],
-                environ["ROUTE53_HOSTNAME"],
-                event["detail"]["EC2InstanceId"],
-                int(environ["ROUTE53_TTL"]),
-            )
+            try:
+                add_record(
+                    environ["ROUTE53_ZONE_ID"],
+                    environ["ROUTE53_ZONE_NAME"],
+                    environ["ROUTE53_HOSTNAME"],
+                    event["detail"]["EC2InstanceId"],
+                    int(environ["ROUTE53_TTL"]),
+                )
+            except ClientError as err:
+                print(f"{err}")
+                lifecycle_result = "ABANDON"
+
     finally:
         complete_lifecycle_action(
             lifecyclehookname=event["detail"]["LifecycleHookName"],
             autoscalinggroupname=event["detail"]["AutoScalingGroupName"],
             lifecycleactiontoken=event["detail"]["LifecycleActionToken"],
             instanceid=event["detail"]["EC2InstanceId"],
+            lifecycleactionresult=lifecycle_result
         )


### PR DESCRIPTION
Sometimes the describe_instances() result doesn't contain
PublicIPAddress. In that case, try to fetch the public IP from tags.
The tag is supposed to be set by the launching lifecycle hook.
