### PR TITLE
Configure logging for release.infrahouse.com

### DIFF
--- a/modules/release.infrahouse.com/bucket.tf
+++ b/modules/release.infrahouse.com/bucket.tf
@@ -40,3 +40,7 @@ resource "aws_s3_object" "index-html" {
   content_type = "text/html"
   etag         = filemd5("${path.module}/index.html")
 }
+
+resource "aws_s3_bucket" "infrahouse-release-logs" {
+  bucket = "infrahouse-release-logs"
+}

--- a/modules/release.infrahouse.com/cloudfront.tf
+++ b/modules/release.infrahouse.com/cloudfront.tf
@@ -43,6 +43,10 @@ resource "aws_cloudfront_distribution" "infrahouse-release" {
     }
   }
 
+  logging_config {
+    bucket = aws_s3_bucket.infrahouse-release-logs.bucket
+  }
+
 }
 
 resource "aws_cloudfront_cache_policy" "default" {


### PR DESCRIPTION
The access logs are collected in s3://infrahouse-release-logs/
