### PR TITLE
Fix logging destination

### DIFF
--- a/modules/release.infrahouse.com/cloudfront.tf
+++ b/modules/release.infrahouse.com/cloudfront.tf
@@ -44,7 +44,7 @@ resource "aws_cloudfront_distribution" "infrahouse-release" {
   }
 
   logging_config {
-    bucket = aws_s3_bucket.infrahouse-release-logs.bucket
+    bucket = aws_s3_bucket.infrahouse-release-logs.bucket_domain_name
   }
 
 }


### PR DESCRIPTION
The destination should be a bucket domain name, not the bucket name.
