### PR TITLE
Do not retry update_dns()

### DIFF
--- a/modules/jumphost/lambda.tf
+++ b/modules/jumphost/lambda.tf
@@ -123,6 +123,11 @@ resource "aws_lambda_function" "update_dns" {
   ]
 }
 
+resource "aws_lambda_function_event_invoke_config" "update_dns" {
+  function_name          = aws_lambda_function.update_dns.function_name
+  maximum_retry_attempts = 0
+}
+
 resource "aws_lambda_permission" "allow_cloudwatch" {
   statement_id  = "AllowExecutionFromCloudWatch-out"
   action        = "lambda:InvokeFunction"


### PR DESCRIPTION
Why? The first invocation continues a lifecycle hook. The second lambda
invocation cannot suceed because a lifecycle hook token is not valid
anymore.

Alternatively, the lambda doesn't have to complete the LC hook action.
However I'd like to control the retry logic (if it's needed in future).
