### PR TITLE
Specify jumphost version via codename

### DIFF
--- a/modules/jumphost/data_sources.tf
+++ b/modules/jumphost/data_sources.tf
@@ -5,12 +5,12 @@ data "aws_iam_policy_document" "jumphost_permissions" {
   }
 }
 
-data "aws_ami" "ubuntu_22" {
+data "aws_ami" "ubuntu" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-${var.ubuntu_codename}-*"]
   }
 
   filter {
@@ -21,6 +21,13 @@ data "aws_ami" "ubuntu_22" {
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
+  }
+
+  filter {
+    name = "state"
+    values = [
+      "available"
+    ]
   }
 
   owners = ["099720109477"] # Canonical
@@ -59,7 +66,7 @@ data "template_cloudinit_config" "jumphost" {
             apt : {
               sources : {
                 infrahouse : {
-                  source : "deb https://release-$RELEASE.infrahouse.com/ $RELEASE main"
+                  source : "deb [signed-by=$KEY_FILE] https://release-${var.ubuntu_codename}.infrahouse.com/ $RELEASE main"
                   key : var.gpg_public_key
                 }
               }

--- a/modules/jumphost/main.tf
+++ b/modules/jumphost/main.tf
@@ -10,7 +10,7 @@ resource "aws_launch_template" "jumphost" {
   name_prefix   = "jumphost-"
   instance_type = "t3a.micro"
   key_name      = var.keypair_name
-  image_id      = var.ami_id == null ? data.aws_ami.ubuntu_22.id : var.ami_id
+  image_id      = var.ami_id == null ? data.aws_ami.ubuntu.id : var.ami_id
   iam_instance_profile {
     arn = module.jumphost_profile.instance_profile_arn
   }

--- a/modules/jumphost/variables.tf
+++ b/modules/jumphost/variables.tf
@@ -44,3 +44,9 @@ variable "route53_ttl" {
   type        = number
   default     = 300
 }
+
+variable "ubuntu_codename" {
+  description = "Ubuntu version to use for the jumphost"
+  type        = string
+  default     = "jammy"
+}


### PR DESCRIPTION
Two reasons:
* Cloudinit doesn't replace $RELEASE in a URL, so need to build url
* Avility to use other versions than jammy. Will be useful for OS
upgrades
