### PR TITLE
Add role infrahouse-toolkit-github

### DIFF
--- a/aws_iam_role.infrahouse-toolkit-github.tf
+++ b/aws_iam_role.infrahouse-toolkit-github.tf
@@ -1,0 +1,40 @@
+## Roles for CI/CD in the infrahouse-toolkit repo
+
+data "aws_iam_policy_document" "github-assume" {
+  statement {
+    sid     = "010"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type = "Federated"
+      identifiers = [
+        module.github-connector.gh_openid_connect_provider_arn
+      ]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values = [
+        "sts.amazonaws.com"
+      ]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "repo:infrahouse/infrahouse-toolkit:ref:refs/heads/main"
+      ]
+    }
+  }
+}
+
+
+resource "aws_iam_role" "infrahouse-toolkit-github" {
+  name               = "infrahouse-toolkit-github"
+  description        = "Role for a GitHub Actions runner in a infrahouse-toolkit repo."
+  assume_role_policy = data.aws_iam_policy_document.github-assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "infrahouse-toolkit-github" {
+  policy_arn = aws_iam_policy.package-publisher.arn
+  role       = aws_iam_role.infrahouse-toolkit-github.name
+}


### PR DESCRIPTION
The GitHub Actions worker will assume this role. The role will have
permissions to upload a debian package to the infrahouse debian
repository.
