### PR TITLE
Fix trust policy

### DIFF
--- a/aws_iam_role.infrahouse-toolkit-github.tf
+++ b/aws_iam_role.infrahouse-toolkit-github.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "github-assume" {
       ]
     }
     condition {
-      test     = "StringLike"
+      test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
       values = [
         "repo:infrahouse/infrahouse-toolkit:ref:refs/heads/main"


### PR DESCRIPTION
We want to allow access to AWS only from the branch main. So, StringEquals
