### PR TITLE
Try non-compressed userdata

### DIFF
--- a/modules/jumphost/data_sources.tf
+++ b/modules/jumphost/data_sources.tf
@@ -38,8 +38,8 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 data "template_cloudinit_config" "jumphost" {
-  gzip          = true
-  base64_encode = true
+  gzip          = false
+  base64_encode = false
 
   part {
     content_type = "text/cloud-config"


### PR DESCRIPTION
It seems, puppet's facter has a problem with gzip-compressed userdata.

Can't confirm, `facter` is producing following error
```
[2023-07-31 02:52:15.279430 ] DEBUG Facter::LegacyFactFormatter -
Converting hash to pretty json
/opt/puppetlabs/puppet/lib/ruby/3.2.0/json/common.rb:406:in `to_json':
source sequence is illegal/malformed utf-8 (JSON::GeneratorError)
        from /opt/puppetlabs/puppet/lib/ruby/3.2.0/json/common.rb:406:in
`generate'
        from /opt/puppetlabs/puppet/lib/ruby/3.2.0/json/common.rb:406:in
`pretty_generate'
        from
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/formatters/legacy_fact_formatter.rb:63:in
`hash_to_facter_format'
        from
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/formatters/legacy_fact_formatter.rb:26:in
`format_for_no_query'
        from
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/formatters/legacy_fact_formatter.rb:16:in
`format'
        from
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter.rb:465:in
`to_user_output'
        from
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/cli/cli.rb:124:in
`query'
        from
/opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor/command.rb:27:in
`run'
        from
/opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in
`invoke_command'
        from
/opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor.rb:392:in
`dispatch'
        from
/opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor/base.rb:485:in
`start'
        from
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/framework/cli/cli_launcher.rb:23:in
`start'
        from /opt/puppetlabs/puppet/bin/facter:10:in `<main>'
```
