### PR TITLE
Re-enable base64

### DIFF
--- a/modules/jumphost/data_sources.tf
+++ b/modules/jumphost/data_sources.tf
@@ -39,7 +39,7 @@ data "aws_region" "current" {}
 
 data "template_cloudinit_config" "jumphost" {
   gzip          = false
-  base64_encode = false
+  base64_encode = true
 
   part {
     content_type = "text/cloud-config"


### PR DESCRIPTION
terraform isn't happy
```
Error: creating EC2 Launch Template (lt-01a8ef96822b4b00b) Version:
InvalidUserData.Malformed: Invalid BASE64 encoding of user data.
	status code: 400, request id:
0553ded3-4a8f-4f6d-90b8-a78e4c556053
```
