### PR TITLE
Fix zone where the NS records are created

### DIFF
--- a/route53.cicd.infrahouse.com.tf
+++ b/route53.cicd.infrahouse.com.tf
@@ -2,7 +2,7 @@ resource "aws_route53_record" "ci-cd-ns" {
   provider = aws.aws-493370826424-uw1
   name     = data.aws_route53_zone.cicd-ih-com.name
   type     = "NS"
-  zone_id  = data.aws_route53_zone.cicd-ih-com.zone_id
+  zone_id  = module.infrahouse_com.infrahouse_zone_id
   ttl      = 172800
   records  = data.aws_route53_zone.cicd-ih-com.name_servers
 }


### PR DESCRIPTION
The NS records of the subdomain should be created in a zone of the
parent, not in the subdomain's zone.

So, zone_id should be of infrahouse.com, not ci-cd.infrahouse.com
