### PR TITLE
Recreate role for puppet-code repo

### DIFF
--- a/aws_iam_role.puppet-code-github.tf
+++ b/aws_iam_role.puppet-code-github.tf
@@ -1,42 +1,17 @@
 ## Roles for CI/CD in the puppet-code repo
 
-data "aws_iam_policy_document" "puppet-code-github-assume" {
-  statement {
-    sid     = "010"
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    principals {
-      type = "Federated"
-      identifiers = [
-        module.github-connector.gh_openid_connect_provider_arn
-      ]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "token.actions.githubusercontent.com:aud"
-      values = [
-        "sts.amazonaws.com"
-      ]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "token.actions.githubusercontent.com:sub"
-      values = [
-        "repo:infrahouse/puppet-code:ref:refs/heads/main"
-      ]
-    }
+module "puppet-code-github" {
+  providers = {
+    aws = aws.aws-493370826424-uw1
   }
-}
-
-
-resource "aws_iam_role" "puppet-code-github" {
-  provider           = aws.aws-493370826424-uw1
-  name               = "puppet-code-github"
-  description        = "Role for a GitHub Actions runner in a puppet-code repo."
-  assume_role_policy = data.aws_iam_policy_document.puppet-code-github-assume.json
+  source      = "infrahouse/github-role/aws"
+  version     = "~> 1.0"
+  gh_org_name = "infrahouse"
+  repo_name   = "puppet-code"
 }
 
 resource "aws_iam_role_policy_attachment" "puppet-code-github" {
   provider   = aws.aws-493370826424-uw1
   policy_arn = aws_iam_policy.package-publisher.arn
-  role       = aws_iam_role.puppet-code-github.name
+  role       = module.puppet-code-github.github_role_name
 }


### PR DESCRIPTION
As long as there is a module for a github actions role, use it for
the puppet-code repo. The role name will change, this is intentional. I
want to test how role names unification works. I.e. which is better -
custom or patterned names.
