### PR TITLE
Delete jumphost during migration

### DIFF
--- a/jumphost.tf
+++ b/jumphost.tf
@@ -4,21 +4,21 @@ resource "aws_key_pair" "aleks" {
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDpgAP1z1Lxg9Uv4tam6WdJBcAftZR4ik7RsSr6aNXqfnTj4civrhd/q8qMqF6wL//3OujVDZfhJcffTzPS2XYhUxh/rRVOB3xcqwETppdykD0XZpkHkc8XtmHpiqk6E9iBI4mDwYcDqEg3/vrDAGYYsnFwWmdDinxzMH1Gei+NPTmTqU+wJ1JZvkw3WBEMZKlUVJC/+nuv+jbMmCtm7sIM4rlp2wyzLWYoidRNMK97sG8+v+mDQol/qXK3Fuetj+1f+vSx2obSzpTxL4RYg1kS6W1fBlSvstDV5bQG4HvywzN5Y8eCpwzHLZ1tYtTycZEApFdy+MSfws5vPOpggQlWfZ4vA8ujfWAF75J+WABV4DlSJ3Ng6rLMW78hVatANUnb9s4clOS8H6yAjv+bU3OElKBkQ10wNneoFIMOA3grjPvPp5r8dI0WDXPIznJThDJO5yMCy3OfCXlu38VDQa1sjVj1zAPG+Vn2DsdVrl50hWSYSB17Zww0MYEr8N5rfFE= aleks@MediaPC"
 }
 
-module "jumphost" {
-  source  = "infrahouse/jumphost/aws"
-  version = "= 1.4.0"
-  providers = {
-    aws = aws.aws-493370826424-uw1
-  }
-  keypair_name    = aws_key_pair.aleks.key_name
-  subnet_ids      = module.management.subnet_public_ids
-  environment     = var.environment
-  route53_zone_id = module.infrahouse_com.infrahouse_zone_id
-  extra_policies = {
-    (aws_iam_policy.package-publisher.name) : aws_iam_policy.package-publisher.arn
-  }
-  puppet_hiera_config_path = "/opt/infrahouse-puppet-data/environments/${var.environment}/hiera.yaml"
-  packages = [
-    "infrahouse-puppet-data"
-  ]
-}
+#module "jumphost" {
+#  source  = "infrahouse/jumphost/aws"
+#  version = "= 1.4.0"
+#  providers = {
+#    aws = aws.aws-493370826424-uw1
+#  }
+#  keypair_name    = aws_key_pair.aleks.key_name
+#  subnet_ids      = module.management.subnet_public_ids
+#  environment     = var.environment
+#  route53_zone_id = module.infrahouse_com.infrahouse_zone_id
+#  extra_policies = {
+#    (aws_iam_policy.package-publisher.name) : aws_iam_policy.package-publisher.arn
+#  }
+#  puppet_hiera_config_path = "/opt/infrahouse-puppet-data/environments/${var.environment}/hiera.yaml"
+#  packages = [
+#    "infrahouse-puppet-data"
+#  ]
+#}


### PR DESCRIPTION
jumphost stays in a way of migrating the service network - disabling it temporarily.
