### PR TITLE
Create role infrahouse-toolkit-github with module

### DIFF
--- a/aws_iam_role.infrahouse-toolkit-github.tf
+++ b/aws_iam_role.infrahouse-toolkit-github.tf
@@ -1,42 +1,10 @@
 ## Roles for CI/CD in the infrahouse-toolkit repo
-
-data "aws_iam_policy_document" "github-assume" {
-  statement {
-    sid     = "010"
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    principals {
-      type = "Federated"
-      identifiers = [
-        module.github-connector.gh_openid_connect_provider_arn
-      ]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "token.actions.githubusercontent.com:aud"
-      values = [
-        "sts.amazonaws.com"
-      ]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "token.actions.githubusercontent.com:sub"
-      values = [
-        "repo:infrahouse/infrahouse-toolkit:ref:refs/heads/main"
-      ]
-    }
+module "infrahouse-toolkit-github" {
+  providers = {
+    aws = aws.aws-493370826424-uw1
   }
-}
-
-
-resource "aws_iam_role" "infrahouse-toolkit-github" {
-  provider           = aws.aws-493370826424-uw1
-  name               = "infrahouse-toolkit-github"
-  description        = "Role for a GitHub Actions runner in a infrahouse-toolkit repo."
-  assume_role_policy = data.aws_iam_policy_document.github-assume.json
-}
-
-resource "aws_iam_role_policy_attachment" "infrahouse-toolkit-github" {
-  provider   = aws.aws-493370826424-uw1
-  policy_arn = aws_iam_policy.package-publisher.arn
-  role       = aws_iam_role.infrahouse-toolkit-github.name
+  source      = "infrahouse/github-role/aws"
+  version     = "~> 1.0"
+  gh_org_name = "infrahouse"
+  repo_name   = "infrahouse-toolkit"
 }

--- a/release.infrahouse.com.tf
+++ b/release.infrahouse.com.tf
@@ -23,5 +23,6 @@ module "release_infrahouse_com" {
   bucket_admin_roles = [
     module.infrahouse-puppet-data-github.github_role_arn,
     module.puppet-code-github.github_role_arn,
+    module.infrahouse-toolkit-github.github_role_arn
   ]
 }


### PR DESCRIPTION
The role existed, but it was created from individual resources. Wrap it
in a module for more uniform role creation and to pass the role to
bucket admins in the debian repo.
