### PR TITLE
The re-attach package-publisher to ih-tf-infrahouse-toolkit-github

### DIFF
--- a/aws_iam_role.infrahouse-toolkit-github.tf
+++ b/aws_iam_role.infrahouse-toolkit-github.tf
@@ -8,3 +8,9 @@ module "infrahouse-toolkit-github" {
   gh_org_name = "infrahouse"
   repo_name   = "infrahouse-toolkit"
 }
+
+resource "aws_iam_role_policy_attachment" "infrahouse-toolkit-github" {
+  provider   = aws.aws-493370826424-uw1
+  policy_arn = aws_iam_policy.package-publisher.arn
+  role       = module.infrahouse-toolkit-github.github_role_name
+}


### PR DESCRIPTION
The ih-tf-infrahouse-toolkit-github role needs more privileges besides
accessing the releases bucket. It also needs to read secrets for
authentication.
