### PR TITLE
Create secret for GitHub token

### DIFF
--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -1,24 +1,5 @@
-resource "aws_secretsmanager_secret" "runner_token_secret" {
-  provider                = aws.aws-493370826424-uw1
-  name                    = "runner_token_secret"
-  description             = "Token to register a GitHub Actions runner."
+resource "aws_secretsmanager_secret" "github_token" {
+  name                    = "GITHUB_TOKEN"
+  description             = "GitHub token with manage_runners:org permissions. Needed to register self-hosted runners."
   recovery_window_in_days = 0
-}
-
-data "aws_iam_policy_document" "github_runner_permissions" {
-  statement {
-    actions = [
-      "secretsmanager:*",
-    ]
-    resources = [
-      aws_secretsmanager_secret.runner_token_secret.arn
-    ]
-  }
-}
-
-resource "aws_iam_policy" "github_runner_permissions" {
-  provider    = aws.aws-493370826424-uw1
-  name        = "github_runner_permissions"
-  description = "Policy that allows to manage github runner token"
-  policy      = data.aws_iam_policy_document.github_runner_permissions.json
 }

--- a/jumphost.tf
+++ b/jumphost.tf
@@ -23,10 +23,16 @@ module "jumphost" {
   route53_zone_id = module.infrahouse_com.infrahouse_zone_id
   extra_policies = {
     (aws_iam_policy.package-publisher.name) : aws_iam_policy.package-publisher.arn
-    (aws_iam_policy.github_runner_permissions.name) : aws_iam_policy.github_runner_permissions.arn
   }
   puppet_hiera_config_path = "/opt/infrahouse-puppet-data/environments/${var.environment}/hiera.yaml"
   packages = [
     "infrahouse-puppet-data"
   ]
+  #  extra_files = [
+  #    {
+  #      content : "export GITHUB_TOKEN="
+  #      path : "/etc/profile.d/github.sh"
+  #      permissions : "0600"
+  #    }
+  #  ]
 }


### PR DESCRIPTION
The token will be used in jumphost, to register GitHub self hosted
runners.
