### PR TITLE
Pass GitHub token to jumphost

### DIFF
--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -3,3 +3,7 @@ resource "aws_secretsmanager_secret" "github_token" {
   description             = "GitHub token with manage_runners:org permissions. Needed to register self-hosted runners."
   recovery_window_in_days = 0
 }
+
+data "aws_secretsmanager_secret_version" "github_token" {
+  secret_id = aws_secretsmanager_secret.github_token.id
+}

--- a/jumphost.tf
+++ b/jumphost.tf
@@ -28,11 +28,11 @@ module "jumphost" {
   packages = [
     "infrahouse-puppet-data"
   ]
-  #  extra_files = [
-  #    {
-  #      content : "export GITHUB_TOKEN="
-  #      path : "/etc/profile.d/github.sh"
-  #      permissions : "0600"
-  #    }
-  #  ]
+  extra_files = [
+    {
+      content : "export GITHUB_TOKEN=${data.aws_secretsmanager_secret_version.github_token.secret_string}"
+      path : "/etc/profile.d/github.sh"
+      permissions : "0600"
+    }
+  ]
 }


### PR DESCRIPTION
The jumphost will perform a role of github_runner. For that it needs
GITHUB_TOKEN with managerunner access. Pass it and make it available for
root only.
