### PR TITLE
Enable and configure CORS in tapir

### DIFF
--- a/registry.tf
+++ b/registry.tf
@@ -63,7 +63,7 @@ module "ecs" {
     },
     {
       name : "JAVA_OPTS"
-      value : "-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dquarkus.http.cors=false"
+      value : "-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dquarkus.http.cors=true -Dquarkus.http.cors.origins=https://registry.${module.infrahouse_com.infrahouse_zone_name}"
     }
   ]
   task_role_arn = aws_iam_role.registry-node.arn


### PR DESCRIPTION
I'm getting a weird CORS error in 0.7
```
POST /management/deploykey/infrahouse-bookstack-aws HTTP/1.1
X-Forwarded-For: 23.123.142.164
X-Forwarded-Proto: https
X-Forwarded-Port: 443
Host: registry.infrahouse.com
X-Amzn-Trace-Id: Root=1-664fd265-7f9d22b3739dae9e74f069e0
Content-Length: 0
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:126.0) Gecko/20100101 Firefox/126.0
accept: */*
accept-language: en-US,en;q=0.5
accept-encoding: gzip, deflate, br, zstd
referer: https://registry.infrahouse.com/management
origin: https://registry.infrahouse.com
dnt: 1
sec-fetch-dest: empty
sec-fetch-mode: cors
sec-fetch-site: same-origin
priority: u=1
cookie: q_auth_742...
```

```
HTTP/1.1 403 CORS Rejected - Invalid origin
content-length: 0
```

Not sure why tapir/quarkus doesn't respect `-Dquarkus.http.cors=false`,
let's try to configure it.
