### PR TITLE
Downgrade tapir to 0.6.0

### DIFF
--- a/registry.tf
+++ b/registry.tf
@@ -10,7 +10,7 @@ module "ecs" {
   dns_names = [
     "registry"
   ]
-  docker_image                          = "pacovk/tapir:0.6"
+  docker_image                          = "pacovk/tapir:0.6.0"
   internet_gateway_id                   = module.management.internet_gateway_id
   load_balancer_subnets                 = module.management.subnet_public_ids
   service_name                          = "terraform-registry"


### PR DESCRIPTION
Tapir generates a URL with an "s3:" prefix. Maybe that's why terraform uses AWS sdk to download the module instead of using the http URL.
```
│ Could not download module "ecs" (registry.tf:1) source code from
│ "s3::https://infrahou
```