### PR TITLE
Bump tapir to 0.7.0

### DIFF
--- a/registry.tf
+++ b/registry.tf
@@ -10,7 +10,7 @@ module "ecs" {
   dns_names = [
     "registry"
   ]
-  docker_image                          = "pacovk/tapir:0.6.0"
+  docker_image                          = "pacovk/tapir:0.7.0"
   internet_gateway_id                   = module.management.internet_gateway_id
   load_balancer_subnets                 = module.management.subnet_public_ids
   service_name                          = "terraform-registry"


### PR DESCRIPTION
The s3: prefix causes an AWS error. 
When a user doesn't have AWS config, Terraform complains. When it does, Terraform uses AWS SDK to download an archive instead of HTTP
```
commit c05220cde2f77f36e1ec865de26d357cafc0268c
Author: Pascal Euhus <pascal.euhus@gmx.de>
Date:   Fri Jan 5 10:07:36 2024 +0100

    no need to prepend modules with s3://

diff --git a/src/main/java/api/Modules.java b/src/main/java/api/Modules.java
index 64380d6..d4036b3 100644
--- a/src/main/java/api/Modules.java
+++ b/src/main/java/api/Modules.java
@@ -79,8 +79,7 @@ public class Modules {
           throws StorageException {
     Module module = new Module(namespace, name, provider, version);
     String path = StorageUtil.generateModuleStoragePath(module);
-    String signedUrl = storageService.getDownloadUrlForArtifact(path);
-    String downloadUrl = String.format("s3::%s", signedUrl);
+    String downloadUrl = storageService.getDownloadUrlForArtifact(path);
```