### PR TITLE
Add VPN routes

### DIFF
--- a/vpn.tf
+++ b/vpn.tf
@@ -9,6 +9,12 @@ module "vpn" {
   lb_subnet_ids              = module.management.subnet_public_ids
   google_oauth_client_writer = data.aws_iam_role.AWSAdministratorAccess.arn
   zone_id                    = module.infrahouse_com.infrahouse_zone_id
+  routes = [
+    {
+      network : cidrhost(module.management.vpc_cidr_block, 0)
+      netmask : cidrnetmask(module.management.vpc_cidr_block)
+    }
+  ]
 }
 
 data "aws_iam_role" "AWSAdministratorAccess" {


### PR DESCRIPTION
We want to let VPN cliens reach certain networks. For that, we push the management VPC network range to the VPN client configuration.
