### PR TITLE
Increase ELB healthcheck grace period on VPN to 900 seconds

### DIFF
--- a/vpn.tf
+++ b/vpn.tf
@@ -1,6 +1,6 @@
 module "vpn" {
   source  = "registry.infrahouse.com/infrahouse/openvpn/aws"
-  version = "~> 0.7"
+  version = "0.7.1"
   providers = {
     aws     = aws
     aws.dns = aws


### PR DESCRIPTION
Target group health check should give time to run puppet.
