### PR TITLE
Upgrade VPN to t3a.micro

### DIFF
--- a/vpn.tf
+++ b/vpn.tf
@@ -12,7 +12,7 @@ module "vpn" {
   asg_max_size               = 1
   asg_min_size               = 1
   on_demand_base_capacity    = 0
-  instance_type              = "t3a.nano"
+  instance_type              = "t3a.micro"
   portal_instance_type       = "t3a.nano"
   portal_workers_count       = 1
 


### PR DESCRIPTION
t3a.nano can't run puppet anymore.

```
[  174.058938] cloud-init[1642]: {"action":"install","module_name":"infrahouse-profile","module_version":">= 0.1.0 < 1.0.0","result":"noop","version":"0.1.0"}

         Starting [0;1;39mDownload data forâ¦led at package install time[0m...

[[0;32m  OK  [0m] Finished [0;1;39mDownload data forâ¦ailed at package install time[0m.

         Starting [0;1;39mTime & Date Service[0m...

[[0;32m  OK  [0m] Started [0;1;39mTime & Date Service[0m.

```
