### PR TITLE
Change to ListHostedZones

### DIFF
--- a/selfdrivedb.app.tf
+++ b/selfdrivedb.app.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "ha-permissions" {
   statement {
     resources = ["*"]
     actions = [
-      "route53:ListHostedZonesByName"
+      "route53:ListHostedZones"
     ]
   }
 }


### PR DESCRIPTION
Let's encrypt calls `ListHostedZones`

```
An error occurred (AccessDenied) when calling the ListHostedZones operation: User: arn:aws:iam::493370826424:user/home-assitant is not authorized to perform: route53:ListHostedZones because no identity-based policy allows the route53:ListHostedZones action
```

