### PR TITLE
Upgrade infrahouse/github-backup to 6.0

### DIFF
--- a/infrahouse-github-backup.tf
+++ b/infrahouse-github-backup.tf
@@ -14,9 +14,8 @@ module "infrahouse-github-backup-app-key" {
 
 module "terraform-aws-github-backup" {
   source                   = "registry.infrahouse.com/infrahouse/github-backup/aws"
-  version                  = "0.5.2"
+  version                  = "0.6.0"
   app_key_secret           = module.infrahouse-github-backup-app-key.secret_name
-  key_pair_name            = aws_key_pair.aleks.key_name
   subnets                  = module.management.subnet_private_ids
   instance_type            = "t3a.small"
   environment              = var.environment


### PR DESCRIPTION
and use a generated SSH key for github-backup instances
