### PR TITLE
Upgrade infrahouse/github-backup/aws to 0.6.4

### DIFF
--- a/infrahouse-github-backup.tf
+++ b/infrahouse-github-backup.tf
@@ -14,7 +14,7 @@ module "infrahouse-github-backup-app-key" {
 
 module "terraform-aws-github-backup" {
   source                   = "registry.infrahouse.com/infrahouse/github-backup/aws"
-  version                  = "0.6.3"
+  version                  = "0.6.4"
   app_key_secret           = module.infrahouse-github-backup-app-key.secret_name
   subnets                  = module.management.subnet_private_ids
   instance_type            = "t3a.small"


### PR DESCRIPTION
to fix

```
May 31 17:32:48 ip-10-0-3-252.infrahouse.com teleport[10919]: 2025-05-31T17:32:48.882Z WARN [CLOUDLABE] Could not fetch EC2 instance's tags, please ensure 'allow instance tags in metadata' is enabled on the instance. labels/cloud.go:147
```