### PR TITLE
Revert HA for registry & keycloak

### DIFF
--- a/keycloak.tf
+++ b/keycloak.tf
@@ -25,9 +25,9 @@ module "keycloak" {
   container_command             = ["start"]
   healthcheck_path              = "/health"
   asg_instance_type             = "t3.small"
-  asg_min_size                  = 2
-  asg_max_size                  = 2
-  task_min_count                = 4
+  asg_min_size                  = 1
+  asg_max_size                  = 1
+  task_min_count                = 1
   on_demand_base_capacity       = 0
   healthcheck_interval          = 60
   container_memory              = "512"

--- a/registry.tf
+++ b/registry.tf
@@ -16,9 +16,9 @@ module "ecs" {
   service_name                          = "terraform-registry"
   ssh_key_name                          = aws_key_pair.aleks-Black-MBP.key_name
   zone_id                               = module.infrahouse_com.infrahouse_zone_id
-  asg_max_size                          = 2
-  asg_min_size                          = 2
-  task_min_count                        = 4
+  asg_max_size                          = 1
+  asg_min_size                          = 1
+  task_min_count                        = 1
   on_demand_base_capacity               = 0
   alb_healthcheck_interval              = 300
   alb_healthcheck_path                  = "/"


### PR DESCRIPTION
It doesn't work in the current configuration because target group doesn't enable session stickiness and subsequent requests hit different containers both on the registry side as well as keycloak.
