### PR TITLE
Reduce number of tasks to one

### DIFF
--- a/keycloak.tf
+++ b/keycloak.tf
@@ -25,7 +25,8 @@ module "keycloak" {
   container_command             = ["start"]
   healthcheck_path              = "/health"
   asg_instance_type             = "t3.small"
-  task_min_count                = 4
+  task_min_count                = 1
+  task_max_count                = 1
   on_demand_base_capacity       = 0
   healthcheck_interval          = 60
   container_memory              = "512"


### PR DESCRIPTION
Even with stickiness on, the Tapir registry is having problems with authentication.
HTTP requests from the registry hit different targets anyway. I suspect the registry doesn't respect the ALB added cokies.
One way to solve this problem would be debug Tapir and find out why the requests hit different target.
Another approach would be to run the keycloak as a side car container.
While I'm doing the research, reduce number of containes to 1.
