### PR TITLE
Generate webhook secret for InfraHouse GitHub App

### DIFF
--- a/infrahouse-app-github.tf
+++ b/infrahouse-app-github.tf
@@ -16,11 +16,17 @@ module "infrahouse-app-github-app-key" {
   ]
 }
 
+resource "random_password" "infrahouse_app_github_webhook_secret" {
+  length  = 48
+  special = true
+}
+
 module "infrahouse-app-github-webhook-secret" {
   source             = "registry.infrahouse.com/infrahouse/secret/aws"
   version            = "1.1.1"
   secret_description = "GitHub App InfraHouse (SaaS) webhook secret"
   secret_name_prefix = "infrahouse-app-github-webhook-secret"
+  secret_value       = random_password.infrahouse_app_github_webhook_secret.result
   environment        = local.environment
   writers = [
     local.admin_role_arn

--- a/terraform.tf
+++ b/terraform.tf
@@ -15,5 +15,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.11"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `random_password` resource to generate a strong 48-char webhook secret (with special characters)
- Wire the generated value into the `infrahouse-app-github-webhook-secret` module's `secret_value`
- Add `hashicorp/random` provider to `required_providers`

## Test plan
- [ ] `make plan` shows the random_password resource creation and secret update
- [ ] Verify the secret is stored in AWS Secrets Manager after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)