### PR TITLE
Add Secrets Manager secret for GitHub App OAuth credentials

### DIFF
--- a/infrahouse-app-github.tf
+++ b/infrahouse-app-github.tf
@@ -33,6 +33,17 @@ module "infrahouse-app-github-webhook-secret" {
   ]
 }
 
+module "infrahouse-app-github-oauth" {
+  source             = "registry.infrahouse.com/infrahouse/secret/aws"
+  version            = "1.1.1"
+  secret_description = "GitHub App InfraHouse (SaaS) OAuth credentials (JSON: client_id + client_secret)"
+  secret_name_prefix = "infrahouse-app-github-oauth"
+  environment        = local.environment
+  writers = [
+    local.admin_role_arn
+  ]
+}
+
 # The GitHub App - https://github.com/apps/infrahouse
 resource "aws_ssm_parameter" "infrahouse_app_github_app_id" {
   name        = "/infrahouse-app/github-app/app-id"


### PR DESCRIPTION
Adds a Secrets Manager secret (`infrahouse-app-github-oauth`) to store the GitHub App's OAuth client_id and client_secret as a single JSON object:

```json
{
  "client_id": "Iv23liMp9eLZ86yvGDNI",
  "client_secret": "..."
}
```

**After apply:**
1. Generate a client secret on the [GitHub App settings page](https://github.com/organizations/infrahouse/settings/apps/infrahouse)
2. Write the JSON to the new secret via `ih-secrets`

This is needed for the InfraHouse SaaS app's OAuth login flow (`infrahouse.app`).