### PR TITLE
Add GitHub Actions self-hosted runner

### DIFF
--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -1,0 +1,42 @@
+module "actions-runner-pem" {
+  source             = "registry.infrahouse.com/infrahouse/secret/aws"
+  version            = "1.1.1"
+  secret_description = "GitHub App PEM key for actions-runner"
+  secret_name_prefix = "actions-runner-pem"
+  environment        = local.environment
+  writers = [
+    local.admin_role_arn
+  ]
+}
+
+module "actions-runner-noble" {
+  source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
+  version = "4.0.0"
+  providers = {
+    aws = aws.aws-493370826424-uw1
+  }
+
+  environment                = local.environment
+  github_org_name            = "infrahouse"
+  github_app_id              = 1016363
+  github_app_pem_secret_arn  = module.actions-runner-pem.secret_arn
+  subnet_ids                 = module.management.subnet_private_ids
+  role_name                  = "actions-runner-noble"
+  instance_type              = "t3a.small"
+  root_volume_size           = 64
+  max_instance_lifetime_days = 7
+  asg_min_size               = 1
+  on_demand_base_capacity    = 0
+  ubuntu_codename            = "noble"
+  extra_labels               = ["noble"]
+  puppet_hiera_config_path   = "/opt/infrahouse-puppet-data/environments/${local.environment}/hiera.yaml"
+  packages = [
+    "debhelper",
+    "devscripts",
+    "infrahouse-puppet-data",
+    "golang",
+    "packer",
+    "skeema",
+  ]
+  alarm_emails = local.alarm_emails
+}


### PR DESCRIPTION
## Summary
- Adds `actions-runner` module (v4.0.0) to deploy a self-hosted GitHub Actions runner in account 493370826424
- Creates a PEM secret via `infrahouse/secret/aws` — needs to be populated after apply with the same PEM key used in the CI/CD account (GitHub App 1016363)
- Matches CI/CD account runner config: Noble, t3a.small, same packages + skeema

## Post-apply steps
1. Copy the GitHub App PEM key from account 303467602807 secret `action-runner-pem-*` to the new secret in this account
2. Verify runner registers and picks up jobs labeled `self-hosted, Linux, aws_account:493370826424`

## Test plan
- [ ] `make plan` shows expected resources (ASG, launch template, IAM role, secret, Lambda)
- [ ] `make apply` succeeds
- [ ] Populate PEM secret
- [ ] Runner appears in GitHub org settings under Actions > Runners
- [ ] `infrahouse-app` schema-diff-production workflow picks up the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)