### PR TITLE
Grant actions-runner Lambda roles read access to PEM secret

### DIFF
--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -4,6 +4,9 @@ module "actions-runner-pem" {
   secret_description = "GitHub App PEM key for actions-runner"
   secret_name_prefix = "actions-runner-pem"
   environment        = local.environment
+  readers = [
+    "arn:aws:iam::493370826424:role/actions-runner-*",
+  ]
   writers = [
     local.admin_role_arn
   ]

--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -5,7 +5,8 @@ module "actions-runner-pem" {
   secret_name_prefix = "actions-runner-pem"
   environment        = local.environment
   readers = [
-    "arn:aws:iam::493370826424:role/actions-runner-*",
+    "arn:aws:iam::493370826424:role/actions-runner-*_registration*",
+    "arn:aws:iam::493370826424:role/actions-runner-*_deregistration*",
   ]
   writers = [
     local.admin_role_arn


### PR DESCRIPTION
## Summary
- Add `readers` with wildcard `arn:aws:iam::493370826424:role/actions-runner-*` to the PEM secret module
- Fixes `AccessDeniedException` on `secretsmanager:GetSecretValue` from the registration Lambda — the `infrahouse/secret/aws` module's resource policy was explicitly denying the Lambda role

## Test plan
- [ ] `make plan` — secret resource policy updated
- [ ] `make apply` — Lambda can now read the PEM secret
- [ ] Runner registers successfully and picks up jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)