### PR TITLE
Add cross-account secret-consumer role for CMK tests

### DIFF
--- a/aws_iam_role.secret-consumer.tf
+++ b/aws_iam_role.secret-consumer.tf
@@ -1,0 +1,61 @@
+## Cross-account role for terraform-aws-secret CMK integration tests.
+## The secret-tester role in 303467602807 assumes this role to
+## read/write CMK-encrypted secrets created during test runs.
+
+data "aws_iam_policy_document" "secret_consumer_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::303467602807:role/secret-tester"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "secret_consumer" {
+  name               = "secret-consumer"
+  assume_role_policy = data.aws_iam_policy_document.secret_consumer_trust.json
+}
+
+data "aws_iam_policy_document" "secret_consumer_permissions" {
+  statement {
+    sid = "SecretRW"
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+    ]
+    resources = [
+      "arn:aws:secretsmanager:us-west-1:303467602807:secret:*"
+    ]
+  }
+  statement {
+    sid = "UseCmkViaSecretsManager"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values = [
+        "secretsmanager.us-west-1.amazonaws.com"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "secret_consumer_permissions" {
+  name   = "secret-consumer-permissions"
+  policy = data.aws_iam_policy_document.secret_consumer_permissions.json
+}
+
+resource "aws_iam_role_policy_attachment" "secret_consumer" {
+  policy_arn = aws_iam_policy.secret_consumer_permissions.arn
+  role       = aws_iam_role.secret_consumer.name
+}


### PR DESCRIPTION
## Summary
- Adds IAM role `secret-consumer` in account 493370826424 for cross-account CMK-encrypted secret testing
- Trust policy allows `arn:aws:iam::303467602807:role/secret-tester` to assume the role
- Identity policy grants Secrets Manager read/write on 303467602807 secrets and KMS operations scoped via `kms:ViaService` condition

## Context
The `terraform-aws-secret` module has a CMK integration test (`test_module_cmk.py`) that creates a CMK-encrypted secret in account 303467602807 and verifies cross-account access. This role is the 493370826424-side half of that trust relationship.

## Test plan
- [ ] `make plan` — verify the role, policy, and attachment are created as expected
- [ ] `make apply` — deploy the role
- [ ] From `terraform-aws-secret` repo, run `make test-cmk` to verify end-to-end cross-account secret access

🤖 Generated with [Claude Code](https://claude.com/claude-code)