### PR TITLE
Migrate jumphost & actions-runner to InfraHouse Ubuntu Pro AMI; pin providers

### DIFF
--- a/.claude/plans/retire-old-release-codenames.md
+++ b/.claude/plans/retire-old-release-codenames.md
@@ -1,0 +1,95 @@
+# Retire Old Release Codenames (focal, jammy, oracular)
+
+Remove the retired Ubuntu codenames from `release.infrahouse.com.tf`, **one at a time**, keeping
+only **noble**. Same spirit as the GPG-rotation runbook: staged, each step verified before the
+next, and explicit about what's destroyed and what depends on it.
+
+## Context
+
+`release.infrahouse.com.tf` builds one `debian-repo` per codename via a `for_each` over
+`local.supported_codenames = ["focal", "jammy", "noble", "oracular"]` (module
+`registry.infrahouse.com/infrahouse/debian-repo/aws` **3.2.0** — note: still the single
+`gpg_public_key` input, *not* 4.0.0's `gpg_public_keys` list).
+
+Retiring a codename = removing its element from that list. Because the `for_each` key is the
+codename string (a `toset`), Terraform destroys **only** `module.release_infrahouse_com["<codename>"]`
+and its children — noble and the others are untouched (no index-shift risk). Verify that in every
+plan anyway.
+
+## ⚠️ What each removal destroys (and irreversibility)
+
+Removing one codename destroys that module instance's resources:
+- **S3 content bucket** `infrahouse-release-<codename>` — and `bucket_force_destroy = true`, so it
+  is deleted **even though it holds the published `.deb` packages + repo metadata**. That package
+  history is **gone** (not just the infra). Treat as irreversible.
+- S3 access-logs bucket, CloudFront distribution + OAC + cache policy, the HTTP-auth function.
+- **Route53** `release-<codename>.infrahouse.com` A record → the URL starts returning NXDOMAIN/404.
+- **ACM** certificate (us-east-1) + validation records.
+- **Secrets Manager** `packager-key-<codename>` and `packager-passphrase-<codename>` (the signing
+  key + passphrase). The `infrahouse/secret/aws` module governs the deletion/recovery window —
+  check whether they're recoverable or force-deleted before you apply.
+- The globally-unique S3 bucket name `infrahouse-release-<codename>` is released on delete.
+
+**Rollback reality:** re-adding the codename + restoring `files/DEB-GPG-KEY-infrahouse-<codename>`
+and re-applying recreates the *infrastructure*, but **not the packages** (bucket was force-destroyed)
+and not the old signing key/secret values. So the real safety is the pre-flight gate below, not
+rollback.
+
+## Pre-flight gate (run BEFORE removing each codename)
+
+Do not remove a codename until all of these are clear **for that codename**:
+
+- [ ] **No live consumers.** Nothing still has `deb … release-<codename>.infrahouse.com …` in its
+  `sources.list`. cloud-init already dropped focal/jammy/oracular (only `noble` is allowed in
+  `terraform-aws-cloud-init`), but check for legacy long-lived instances / AMIs / one-off boxes.
+- [ ] **No recent traffic.** CloudFront/S3 access logs for the bucket show no meaningful `apt`
+  fetches over a recent window (e.g. last 30 days).
+- [ ] **No code/doc references** to `release-<codename>.infrahouse.com` in other repos
+  (puppet-code, terraform-aws-cloud-init, docs, external READMEs). Grep the org.
+- [ ] **Not mid-rotation.** The noble GPG rotation is a *separate* change on a different codename;
+  don't interleave. Land codename removals when no noble rotation apply/export is in flight.
+
+## Removal procedure (repeat per codename, one at a time)
+
+For `CODENAME` in the chosen order:
+
+- [ ] Pre-flight gate above passes for `CODENAME`.
+- [ ] Remove `"CODENAME"` from `local.supported_codenames` in `release.infrahouse.com.tf`.
+- [ ] `git rm files/DEB-GPG-KEY-infrahouse-CODENAME` (now orphaned).
+- [ ] `terraform plan` — **confirm the plan destroys ONLY `module.release_infrahouse_com["CODENAME"]`
+  resources** (bucket, logs bucket, CloudFront, OAC, cache policy, auth fn, Route53 record, ACM
+  cert + validation, `packager-key-CODENAME` / `packager-passphrase-CODENAME`). No changes to
+  `["noble"]` or any remaining codename. If anything else shows up, stop.
+- [ ] Apply.
+- [ ] Verify destroyed: `dig +short release-CODENAME.infrahouse.com` → empty; `aws s3 ls
+  s3://infrahouse-release-CODENAME` → gone; secrets no longer listed (or in pending-deletion).
+- [ ] Verify **unaffected**: `noble` (and any not-yet-removed codenames) still resolve and
+  `apt-get update` clean against them.
+- [ ] Commit as its own PR (one codename per PR → small, reviewable, easy to bisect).
+
+## Suggested order (adjust to your fleet knowledge)
+
+Least-risk / least-likely-to-have-consumers first, so any surprise dependency surfaces on the
+lowest-stakes repo:
+
+1. [ ] **oracular** — 24.10 interim release, already EOL; least likely to have anything pinned.
+2. [ ] **focal** — 20.04, oldest; keys already expired, cloud-init dropped it long ago.
+3. [ ] **jammy** — 22.04 LTS; most likely to still have a straggler, so do it last with the most
+   scrutiny.
+
+(Order is independent — `for_each` keys by codename — so this is purely about surfacing surprises
+gently, not a technical constraint.)
+
+## Notes / interaction with the GPG rotation
+
+- This is orthogonal to the noble key rotation (`terraform-aws-debian-repo` runbook): that touches
+  only `noble`. Keeping the two changes in separate PRs avoids a scary combined plan.
+- This account still pins `debian-repo` **3.2.0** (`gpg_public_key`). The noble rotation will need
+  a bump to **4.0.0** (`gpg_public_keys` list) — a separate change; don't bundle it with codename
+  removals.
+- After all three are gone, `supported_codenames` should be `["noble"]` and only
+  `files/DEB-GPG-KEY-infrahouse-noble` should remain.
+
+## Cross-references
+- GPG rotation runbook: `terraform-aws-debian-repo/.claude/plans/gpg-key-rotation-design.local.md`
+- Publish-race caveat (relevant if applying near a repo publish): terraform-aws-debian-repo#43

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.45.0"
   constraints = ">= 4.67.0, >= 5.11.0, >= 5.20.0, >= 5.31.0, >= 5.56.0, >= 5.62.0, ~> 6.0, < 7.0.0"
   hashes = [
+    "h1:9122qJaCqbyEPHtx1Tfpf5v6deU6YPDaknHN26Cq+9g=",
     "h1:FP7YjNtp2FM1UEHfwkgdrcyqtNGCeMI2P6HFPGYmDfY=",
     "zh:27e4dfb1122ca2a603a8427b5bb2bd8001f6c8c972bccd6f64dc319806779d4f",
     "zh:395cbba6b316e119102a52e523b7640274be3964569ed33a4a21141e68beb82d",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.4.0"
   constraints = "~> 2.3"
   hashes = [
+    "h1:4fp7byXJGbOU8zqxFM4yYGHzf1kUH8ChT41KK4n9q98=",
     "h1:Bx3XQkBSY3RAGwLZb8hyi8AhvahPNlt4mlyZhW9guOI=",
     "zh:1b0fe71b8e87a068f7cd9faaa733100ab72ab61ce812b8bd2b8e3e6ea3907b2d",
     "zh:2aa9631ad64cfda1eb58f147619b631dadedfaf9453b422aa5ada2d3861183c1",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
 provider "registry.terraform.io/hashicorp/external" {
   version = "2.4.0"
   hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
     "h1:K0eLC86zbhVoyS4THmY00KJZKAQORuz6dt9Ro3xo/wA=",
     "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
     "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
@@ -65,10 +68,32 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.0, >= 3.2.0"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.9.0"
   constraints = ">= 3.0.0, ~> 3.0, >= 3.5.0, ~> 3.5, ~> 3.6"
   hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
     "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
     "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
     "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
@@ -88,8 +113,9 @@ provider "registry.terraform.io/hashicorp/random" {
 
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.3.0"
-  constraints = ">= 4.0.0, ~> 4.0"
+  constraints = ">= 4.0.0"
   hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
     "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
     "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -11,6 +11,40 @@ data "aws_availability_zones" "uw1" {
   state    = "available"
 }
 
+# InfraHouse Ubuntu Pro AMI (noble), built and published publicly from the CI/CD
+# account (303467602807) by infrahouse/infrahouse-ubuntu-pro. Owner-pinned so a
+# same-named public AMI from any other account can never be selected.
+data "aws_ami" "infrahouse_pro_noble" {
+  provider    = aws.aws-493370826424-uw1
+  most_recent = true
+
+  filter {
+    name = "name"
+    values = [
+      "infrahouse-ubuntu-pro-noble-*"
+    ]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name = "state"
+    values = [
+      "available"
+    ]
+  }
+
+  owners = ["303467602807"] # InfraHouse
+}
+
 data "terraform_remote_state" "cicd" {
   backend = "s3"
   config = {

--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -31,6 +31,7 @@ module "actions-runner-noble" {
   asg_min_size               = 1
   on_demand_base_capacity    = 0
   ubuntu_codename            = "noble"
+  ami_id                     = data.aws_ami.infrahouse_pro_noble.id
   extra_labels               = ["noble"]
   puppet_hiera_config_path   = "/opt/infrahouse-puppet-data/environments/${local.environment}/hiera.yaml"
   packages = [

--- a/jumphost.tf
+++ b/jumphost.tf
@@ -5,6 +5,7 @@ module "jumphost" {
     aws = aws.aws-493370826424-uw1
   }
   ubuntu_codename         = "noble"
+  ami_id                  = data.aws_ami.infrahouse_pro_noble.id
   subnet_ids              = module.management.subnet_private_ids
   nlb_subnet_ids          = module.management.subnet_public_ids
   environment             = local.environment

--- a/terraform.tf
+++ b/terraform.tf
@@ -13,11 +13,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.11"
+      version = "6.45.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "3.9.0"
     }
   }
 }


### PR DESCRIPTION
## What

- **AMI migration**: point `jumphost` and `actions-runner-noble` at the InfraHouse-published **Ubuntu Pro noble** AMI (`infrahouse-ubuntu-pro-noble-*`, owner `303467602807`) via a new owner-pinned `data.aws_ami.infrahouse_pro_noble`, instead of the stock Canonical AMIs the modules resolve by default.
  - The InfraHouse AMI ships InfraHouse packages + the APT repo pre-baked → faster boot.
  - Owner-pinned so a same-named public AMI from another account can never be selected.
  - Mirrors the pattern already in `tinyfish/aws-control-prod`.
- **Provider pinning**: `aws` `>= 5.11` → `6.45.0`, `random` `>= 3.0` → `3.9.0` (exact, matching the current lock) per the coding standard. Renovate manages future bumps.
- Adds the `retire-old-release-codenames` plan doc (unrelated follow-up work).

## Why

The account had pending AMI drift (jumphost + actions-runner were about to roll to the latest Canonical AMI). This redirects that refresh to the InfraHouse image instead, and gets the account onto the org-standard base. Landing this first brings the account to a clean baseline before the codename-retirement work begins.

## Plan impact

- `jumphost` + `actions-runner-noble` launch-template `image_id` → InfraHouse AMI (one LT-version bump + instance refresh each).
  - jumphost stays Pro-based; **actions-runner moves plain Ubuntu → Ubuntu Pro + InfraHouse packages**.
- jumphost IAM-policy `(known after apply)` cascade rides along (benign — policy content unchanged).
- Provider lock already at 6.45.0 / 3.9.0, so the constraint change alone is a no-op to resolution.

Review the CI plan comment before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)