### PR TITLE
Upgrade debian-repo to 4.0.0 + enable cross-region replication (noble)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,10 @@
 locals {
-  environment              = "production"
-  alarm_emails             = ["aleks@infrahouse.com"]
+  environment = "production"
+  dr_region   = "us-east-1"
+  alarm_emails = [
+    "aleks@infrahouse.com"
+  ]
+
   terraform_admin_role_arn = "arn:aws:iam::493370826424:role/ih-tf-aws-control-493370826424-admin"
   admin_role_arn           = tolist(data.aws_iam_roles.AWSAdministratorAccess.arns)[0]
 }

--- a/release.infrahouse.com.tf
+++ b/release.infrahouse.com.tf
@@ -16,8 +16,10 @@ module "release_infrahouse_com" {
     aws     = aws.aws-493370826424-uw1
     aws.ue1 = aws.aws-493370826424-ue1
   }
-  source                = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version               = "3.2.0"
+  source             = "registry.infrahouse.com/infrahouse/debian-repo/aws"
+  version            = "4.0.0"
+  replication_region = local.dr_region
+
   bucket_name           = "infrahouse-release-${each.value}"
   repository_codename   = each.value
   package_version_limit = 0
@@ -25,8 +27,10 @@ module "release_infrahouse_com" {
     "amd64",
     "arm64"
   ]
-  domain_name          = "release-${each.value}.infrahouse.com"
-  gpg_public_key       = file("./files/DEB-GPG-KEY-infrahouse-${each.value}")
+  domain_name = "release-${each.value}.infrahouse.com"
+  gpg_public_keys = [
+    file("./files/DEB-GPG-KEY-infrahouse-${each.value}")
+  ]
   gpg_sign_with        = "packager-${each.value}@infrahouse.com"
   index_title          = "InfraHouse Releases Repository"
   index_body           = local.index_body


### PR DESCRIPTION
Upgrades the `release-noble.infrahouse.com` repo module `debian-repo` **3.2.0 → 4.0.0** and enables **cross-region replication** to us-east-1.

## Changes
- `debian-repo` `3.2.0 → 4.0.0`.
- `gpg_public_key` → `gpg_public_keys = [ … ]` — adapts to 4.0.0's list API. **Just wraps the existing noble key — not a key rotation.**
- `replication_region = local.dr_region` (`us-east-1`) — enables CRR: replica buckets (`infrahouse-release-noble-replica`, `-logs`) + replication IAM roles/policies/config for the repo and logs buckets.
- `locals.tf`: add `dr_region = "us-east-1"`.

## Safety — noble packages preserved
4.0.0 refactors the buckets into the `infrahouse/s3-bucket` submodule. Terraform `moved` blocks migrate the existing noble buckets **in state (moved, not replaced)** — verified on a local plan: `aws_s3_bucket.this` is an **in-place, tag-only** update (`+ module_version`), no replacement. Published packages are untouched.

## Expected plan (~20 add / a few change / 0 destroy)
- **Add**: CRR infrastructure (replica buckets in us-east-1, replication roles/policies/config, replica versioning/encryption/PAB/policy).
- **Change (in-place)**: noble CloudFront (`module_version` tag only), noble repo/logs `aws_s3_bucket.this` (tag) + `aws_s3_bucket_policy.this` (recompute — re-adds existing grants + replication statements).
- **No replacement, no destroy** of noble content.

### Note on plan cleanliness
A phantom `github-backup` `github_app_key` secret diff (`module_version 1.3.0 → 1.1.1` + a `null_resource` destroy) can appear from a **stale local module cache** — `terraform-aws-github-backup` pins its secret submodule with a range (`~> 1.1`), and an out-of-date `.terraform/modules` resolved it to 1.1.1 while state/registry are at 1.3.0. CI's fresh `terraform init` re-resolves `~> 1.1 → 1.3.0`, so it should **not** appear in the CI plan. Filing an upstream issue to pin that exactly. Unrelated to this change; value is unchanged regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)