### PR TITLE
Rotate noble GPG key — Phase 2: dual-sign (K_old + K_new)

### DIFF
--- a/release.infrahouse.com.tf
+++ b/release.infrahouse.com.tf
@@ -32,7 +32,10 @@ module "release_infrahouse_com" {
     file("./files/DEB-GPG-KEY-infrahouse-${each.value}"),
     file("./files/DEB-GPG-KEY-infrahouse-noble-2026-07-04")
   ]
-  gpg_sign_with        = "packager-${each.value}@infrahouse.com"
+  gpg_sign_with = join(" ", [
+    "A627B77600190BA51B903453D37A181B689AD619", # expires: 2026-07-20
+    "F251F649638B680236DCF9BB8FF1CE88CA0D5F6D", # expires: 2036-07-01
+  ])
   index_title          = "InfraHouse Releases Repository"
   index_body           = local.index_body
   zone_id              = module.infrahouse_com.infrahouse_zone_id


### PR DESCRIPTION
**Phase 2 of the noble GPG key rotation** — sign the repo with **both** keys. Follows Phase 1 (#393, trust distribution) which is applied and GATE-1-verified (published bundle carries both fingerprints).

## Change
`gpg_sign_with` now lists both fingerprints, so reprepro signs `Release`/`InRelease` with each:
```hcl
gpg_sign_with = join(" ", [
  "A627B77600190BA51B903453D37A181B689AD619", # K_old, expires 2026-07-20
  "F251F649638B680236DCF9BB8FF1CE88CA0D5F6D", # K_new, expires 2036-07-01
])
```
`gpg_public_keys` unchanged (still both keys).

## Prereq (done out-of-band on laptop)
K_new's **secret** key was appended to the `packager-key-noble` secret via `ih-secrets` (K_old retained), so the signer box can sign with both.

## ⚠️ Plan gate — must be tight AND must not revert the secret
Expected: **one** in-place change —
```
~ module.release_infrahouse_com["noble"].aws_s3_object.distributions   # SignWith → both fingerprints
```
**Do not merge if the plan:**
- touches `module.key.aws_secretsmanager_secret_version` / the packager-key secret value (would clobber the out-of-band K_new append), or
- shows any bucket / CloudFront / ACM / replica change, or any replacement.

## Why this is safe
The fleet already trusts both keys (Phase 1). Signing with both means every client validates against whichever key it has — so both old and new boxes stay green through the switch. After apply, reprepro re-signs on the box; then GATE 2:
```bash
curl -fsS https://release-noble.infrahouse.com/dists/noble/InRelease | gpg --verify   # 2 good sigs (A627… + F251…)
sudo apt-get update    # clean on live AND fresh boxes
```
Only after GATE 2 is green fleet-wide do you proceed to Phase 3 (drop K_old from signing, then from the bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)