### PR TITLE
Add route.infrahouse.com CNAME for lemlist custom tracking domain

### DIFF
--- a/modules/infrahouse.com/main.tf
+++ b/modules/infrahouse.com/main.tf
@@ -59,3 +59,14 @@ resource "aws_route53_record" "_gh-infrahouse-o" {
   ]
   ttl = 3600
 }
+
+## lemlist custom tracking domain
+resource "aws_route53_record" "route_lemlist" {
+  name    = "route.${aws_route53_zone.infrahouse_com.name}"
+  type    = "CNAME"
+  zone_id = aws_route53_zone.infrahouse_com.id
+  ttl     = 3600
+  records = [
+    "custom.lemlist.com."
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a CNAME record `route.infrahouse.com` → `custom.lemlist.com.` for lemlist's custom email tracking/link domain.

The record is defined in `modules/infrahouse.com/main.tf` (where all the zone's records live); `route53.infrahouse.com.tf` just instantiates that module.

## Test plan
- CI `make plan` will show the new `aws_route53_record.route_lemlist` to be created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)