### PR TITLE
Rotate noble GPG key — Phase 3: stop signing with K_old

### DIFF
--- a/release.infrahouse.com.tf
+++ b/release.infrahouse.com.tf
@@ -33,7 +33,6 @@ module "release_infrahouse_com" {
     file("./files/DEB-GPG-KEY-infrahouse-noble-2026-07-04")
   ]
   gpg_sign_with = join(" ", [
-    "A627B77600190BA51B903453D37A181B689AD619", # expires: 2026-07-20
     "F251F649638B680236DCF9BB8FF1CE88CA0D5F6D", # expires: 2036-07-01
   ])
   index_title          = "InfraHouse Releases Repository"


### PR DESCRIPTION
Phase 3 (retire) of the noble GPG signing-key rotation.

**Change:** drop `A627B776…689AD619` (K_old, expires **2026-07-20**) from `gpg_sign_with`, leaving only K_new (`F251F649…CA0D5F6D`, expires 2036-07-01). After this applies, reprepro re-signs `Release`/`InRelease` with K_new alone — before K_old expires and signing with it starts failing.

**Safe now:** the repo has been dual-signed for ~2 weeks and every instance trusts both keys, so switching to K_new-only signing is transparent to clients.

**K_old's *public* key stays in the bundle** (`gpg_public_keys`) for this PR — it's removed in a follow-up PR after the K_new-only InRelease is verified in S3.

**After merge/apply, remaining manual steps (not in this PR):**
1. Rewrite `packager-key-noble` secret → K_new only.
2. `ih-s3-reprepro export noble` on the jumphost to force the re-sign (confirm 1 key imported).
3. Verify S3 `InRelease` shows a single Good signature `F251…`.
4. Follow-up PR: drop K_old from `gpg_public_keys`.
5. CloudFront invalidation `/dists/noble/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)